### PR TITLE
Fixed #29

### DIFF
--- a/src/lib/components/section/blog.svelte
+++ b/src/lib/components/section/blog.svelte
@@ -8,7 +8,7 @@
 
 	<h1 class="text-3xl w-full max-w-6xl mx-auto md:text-4xl font-extrabold font-head text-center">My Blog</h1>
 
-<div class="mt-6 p-6 flex flex-wrap justify-center items-center gap-6  w-full ">
+<div class="prose-base mt-6 p-6 flex flex-wrap justify-center items-center gap-6  w-full ">
    {#each posts as post }
     <BlogCard imgUrl={post.imageUrl} title={post.title} tags={post.tags} slug={post.slug.current} published={post.publishedAt} excerpt={post.excerpt}/>
    {/each}


### PR DESCRIPTION
Adjust font size on blog page for better readability

The font size on the blog page appears too small, causing readability issues. Applying the 'prose-md' class to the content container to address the problem. Resolves #29