### PR TITLE
feat: 📈 Add Vercel analytics for tracking page views

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@fontsource/work-sans": "^5.0.16",
 		"@formkit/auto-animate": "^0.8.1",
 		"@sanity/client": "^6.9.3",
+		"@vercel/analytics": "^1.1.1",
 		"@vercel/speed-insights": "^1.0.1",
 		"date-fns": "^2.30.0",
 		"mathjs": "^12.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@sanity/client':
     specifier: ^6.9.3
     version: 6.9.3
+  '@vercel/analytics':
+    specifier: ^1.1.1
+    version: 1.1.1
   '@vercel/speed-insights':
     specifier: ^1.0.1
     version: 1.0.1
@@ -710,6 +713,12 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
+
+  /@vercel/analytics@1.1.1:
+    resolution: {integrity: sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==}
+    dependencies:
+      server-only: 0.0.1
+    dev: false
 
   /@vercel/nft@0.24.4:
     resolution: {integrity: sha512-KjYAZty7boH5fi5udp6p+lNu6nawgs++pHW+3koErMgbRkkHuToGX/FwjN5clV1FcaM3udfd4zW/sUapkMgpZw==}
@@ -2412,6 +2421,10 @@ packages:
     dependencies:
       lru-cache: 6.0.0
     dev: true
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,9 @@
 	import './styles.css';
 import { injectSpeedInsights } from "@vercel/speed-insights/sveltekit"
    import { ProgressBar } from "@prgm/sveltekit-progress-bar";
+   import { inject } from '@vercel/analytics';
+ 
+inject();
 injectSpeedInsights()
 	onMount(() => {
 		$theme = getOrSetItem('theme', 'dark');


### PR DESCRIPTION
Introduce "@vercel/analytics" to inject analytics for tracking page views, improving user engagement and performance insights. This change involves adding the package to "package.json" and "pnpm-lock.yaml", as well as injecting analytics in the layout component. The addition also entails the installation and configuration of the analytics package. This enhancement addresses the need for comprehensive page view tracking.